### PR TITLE
Include the parent folder in the PYTHONPATH at runtime

### DIFF
--- a/scripts/smbcmp-gui
+++ b/scripts/smbcmp-gui
@@ -20,12 +20,22 @@
 
 import re
 import functools
+import sys
 
 import wx
 import wx.stc
 import wx.adv
 import wx.lib.mixins.listctrl
-import smbcmp
+
+try:
+    import smbcmp
+except ImportError:
+    from pathlib import Path
+    path = str(Path(Path(__file__).parent.absolute()).parent.absolute())
+    sys.path.insert(0, path)
+    import smbcmp
+
+
 
 DIFFLIB = 1
 PDML = 2


### PR DESCRIPTION
Prior to this change, to launch smbcmp-gui
you needed to create a shortcut script which
adds the smbcmp folder in the PYTHONPATH,
before launching. This allows smbcmp-gui to
be launched directly.
See: https://stackoverflow.com/a/61235118/8873120

Furthermore, you can now generate a standalone
executable with pyinstaller using the following
command inside the script folder:

pyinstaller --onefile smbcmp-gui \
    --hidden-import configparser \
    --hidden-import xml.etree.ElementTree